### PR TITLE
Migrations work

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## Notes
 
-This api is consumed by 
+This api is consumed by
+
 - https://github.com/thiskevinwang/coffee-code-climb
 - https://github.com/thiskevinwang/you-suck-try-harder
 
@@ -19,8 +20,8 @@ You will need an `ormconfig` file in the root directory (next to `package.json`)
 ```yml
 default:
   type: "postgres"
-  host: "<rds-database-endpoint>"     # update this
-  port: 0000                          # update this
+  host: "<rds-database-endpoint>" # update this
+  port: 0000 # update this
   username: "<rds-database-username>" # update this
   password: "<rds-database-password>" # update this
   database: "postgres"
@@ -42,4 +43,39 @@ default:
     entitiesDir: "src/entity"
     migrationsDir: "src/migration"
     subscribersDir: "src/subscriber"
+```
+
+---
+
+# Migrations
+
+## Generating Migrations
+
+```bash
+typeorm migration:generate -n ExampleMigrationName
+```
+
+This will generate a new migration called `{TIMESTAMP}-ExampleMigrationName.ts` with empty `up` & `down` migrations.
+
+## Running and Reverting Migrations
+
+### ⚠️ WARNING
+
+Make sure your `ormconfig.yml` has the correct values.
+
+- `ts` code that runs the actual server, might read from `process.env.<ENV_VARIABLES>`,
+- the TypeORM CLI will read from `ormconfig.(yml|json|etc)`
+
+  - make sure they're both pointing to the correct databases... You might be unknowingly running migrations on the actual RDS instance 🤣...
+
+- For more info, see the [TypeORM docs](https://github.com/typeorm/typeorm/blob/master/docs/migrations.md#running-and-reverting-migrations)
+
+With `ts-node`:
+
+```bash
+# run
+ts-node ./node_modules/typeorm/cli.js migration:run
+
+# revert
+ts-node ./node_modules/typeorm/cli.js migration:revert
 ```

--- a/index.ts
+++ b/index.ts
@@ -56,7 +56,7 @@ async function main() {
     username: process.env.RDS_DB_USERNAME,
     password: process.env.RDS_DB_PASSWORD,
     database: process.env.RDS_DB_DATABASE,
-    synchronize: true,
+    // synchronize: true,
     logging: false,
     entities: entities,
     migrations: ["src/migration/**/*.ts"],

--- a/src/migration/1584904474346-CreateDummyTable.ts
+++ b/src/migration/1584904474346-CreateDummyTable.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateDummyTable1584904474346 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`
+      CREATE TABLE random_dummy_table
+      (
+        -- SERIAL is a PostgreSQL type
+        -- INTEGER would be used if using SQLite
+        id SERIAL PRIMARY KEY,
+        title VARCHAR NOT NULL,
+        body TEXT NOT NULL,
+        -- 'f' equals false
+        published BOOLEAN NOT NULL DEFAULT 'f'
+      )
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`
+      DROP TABLE random_dummy_table
+    `)
+  }
+}

--- a/src/migration/1584905823148-CreateUsersTable.ts
+++ b/src/migration/1584905823148-CreateUsersTable.ts
@@ -7,7 +7,7 @@ export class CreateUsersTable1584905823148 implements MigrationInterface {
 			-- wrap the tablename in double quotes ("Users")
 			CREATE TABLE "Users"
 			(
-				id SERIAL PRIMARY KEY,
+				id SERIAL PRIMARY KEY UNIQUE,
 				type VARCHAR NOT NULL DEFAULT 'User',
 				username VARCHAR(25) NOT NULL,
 				email VARCHAR(62) NOT NULL,
@@ -23,7 +23,15 @@ export class CreateUsersTable1584905823148 implements MigrationInterface {
 				banned BOOLEAN,
 				deleted TIMESTAMP
 			)
-    `)
+		`)
+    await queryRunner.query(`
+			ALTER TABLE "Users"
+			ADD CONSTRAINT unique_username UNIQUE ("username")
+		`)
+    await queryRunner.query(`
+			ALTER TABLE "Users"
+			ADD CONSTRAINT unique_email UNIQUE ("email")
+		`)
   }
 
   public async down(queryRunner: QueryRunner): Promise<any> {

--- a/src/migration/1584905823148-CreateUsersTable.ts
+++ b/src/migration/1584905823148-CreateUsersTable.ts
@@ -3,7 +3,9 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 export class CreateUsersTable1584905823148 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<any> {
     await queryRunner.query(`
-			CREATE TABLE users
+			-- in order to preserve capital casing in postgres
+			-- wrap the tablename in double quotes ("Users")
+			CREATE TABLE "Users"
 			(
 				id SERIAL PRIMARY KEY,
 				type VARCHAR NOT NULL DEFAULT 'User',
@@ -26,7 +28,7 @@ export class CreateUsersTable1584905823148 implements MigrationInterface {
 
   public async down(queryRunner: QueryRunner): Promise<any> {
     await queryRunner.query(`
-			DROP TABLE users
+			DROP TABLE "Users"
 		`)
   }
 }

--- a/src/migration/1584905823148-CreateUsersTable.ts
+++ b/src/migration/1584905823148-CreateUsersTable.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateUsersTable1584905823148 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`
+			CREATE TABLE users
+			(
+				id SERIAL PRIMARY KEY,
+				type VARCHAR NOT NULL DEFAULT 'User',
+				username VARCHAR(25) NOT NULL,
+				email VARCHAR(62) NOT NULL,
+				password VARCHAR NOT NULL,
+				first_name VARCHAR(50) NOT NULL,
+				last_name VARCHAR(50) NOT NULL,
+				-- NOW() is a postgres date function
+				created TIMESTAMP NOT NULL DEFAULT NOW(),
+				updated TIMESTAMP DEFAULT NOW(),
+				avatar_url VARCHAR(255),
+				last_password_request TIMESTAMP,
+				verified_date TIMESTAMP,
+				banned BOOLEAN,
+				deleted TIMESTAMP
+			)
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`
+			DROP TABLE users
+		`)
+  }
+}

--- a/src/migration/1584908907170-CreateCommentsTable.ts
+++ b/src/migration/1584908907170-CreateCommentsTable.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateCommentsTable1584908907170 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`
+			CREATE TABLE "Comments"
+			(
+				id SERIAL PRIMARY KEY,
+				type VARCHAR NOT NULL DEFAULT 'Comment',
+				body VARCHAR NOT NULL,
+				url VARCHAR NOT NULL,
+				-- NOW() is a postgres date function
+				created TIMESTAMP NOT NULL DEFAULT NOW(),
+				userId INTEGER NOT NULL,
+				deleted TIMESTAMP,
+				updated TIMESTAMP DEFAULT NOW()
+			)
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`
+			DROP TABLE "Comments"
+		`)
+  }
+}

--- a/src/migration/1584908907170-CreateCommentsTable.ts
+++ b/src/migration/1584908907170-CreateCommentsTable.ts
@@ -11,7 +11,7 @@ export class CreateCommentsTable1584908907170 implements MigrationInterface {
 				url VARCHAR NOT NULL,
 				-- NOW() is a postgres date function
 				created TIMESTAMP NOT NULL DEFAULT NOW(),
-				userId INTEGER NOT NULL,
+				userId INTEGER NOT NULL REFERENCES "Users"(id),
 				deleted TIMESTAMP,
 				updated TIMESTAMP DEFAULT NOW()
 			)

--- a/src/migration/1584909849206-CreateReactionsTable.ts
+++ b/src/migration/1584909849206-CreateReactionsTable.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateReactionsTable1584909849206 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`
+			DROP TYPE IF EXISTS "ReactionVariant"
+		`)
+    await queryRunner.query(`
+			CREATE TYPE "ReactionVariant" AS ENUM
+			('Like', 'Love', 'Haha', 'Wow', 'Sad', 'None')
+		`)
+    await queryRunner.query(`
+    	CREATE TABLE "Reactions"
+    	(
+    		id SERIAL PRIMARY KEY UNIQUE,
+    		type VARCHAR NOT NULL DEFAULT 'Reaction',
+    		created TIMESTAMP NOT NULL DEFAULT NOW(),
+    		updated TIMESTAMP DEFAULT NOW(),
+    		commentId INTEGER NOT NULL REFERENCES "Comments"(id),
+    		userId INTEGER NOT NULL REFERENCES "Users"(id),
+    		deleted TIMESTAMP,
+    		variant "ReactionVariant" DEFAULT 'None'
+    	)
+		`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`
+			DROP TYPE "ReactionVariant"
+		`)
+    await queryRunner.query(`
+			DROP TABLE "Reactions"
+		`)
+  }
+}

--- a/src/migration/1584915347629-CreateAttemptsTable.ts
+++ b/src/migration/1584915347629-CreateAttemptsTable.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateAttemptsTable1584915347629 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`
+			CREATE TABLE "Attempts"
+			(
+				id SERIAL PRIMARY KEY,
+				created TIMESTAMP NOT NULL DEFAULT NOW(),
+				updated TIMESTAMP DEFAULT NOW(),
+				deleted TIMESTAMP,
+				grade INTEGER NOT NULL,
+				send BOOLEAN,
+				flash BOOLEAN,
+				date timestamp NOT NULL,
+				userId INTEGER NOT NULL REFERENCES "Users"(id)
+			)
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`
+			DROP TABLE "Attempts
+		`)
+  }
+}

--- a/src/migration/1584915347629-CreateAttemptsTable.ts
+++ b/src/migration/1584915347629-CreateAttemptsTable.ts
@@ -20,7 +20,7 @@ export class CreateAttemptsTable1584915347629 implements MigrationInterface {
 
   public async down(queryRunner: QueryRunner): Promise<any> {
     await queryRunner.query(`
-			DROP TABLE "Attempts
+			DROP TABLE "Attempts"
 		`)
   }
 }


### PR DESCRIPTION
# Description

This adds raw SQL (postgres) migrations for creating the following tables
- `"Users"`
- `"Comments"`
- `"Reactions"`
- `"Attempts"`

and enum
- `"ReactionVariant"`

This turns off `synchronize`