### PR TITLE
Synchronize off & type ResolverFn

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "semi": false,
   "singleQuote": false,
   "tabWidth": 2,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "arrowParens": "avoid"
 }

--- a/index.ts
+++ b/index.ts
@@ -56,7 +56,7 @@ async function main() {
     username: process.env.RDS_DB_USERNAME,
     password: process.env.RDS_DB_PASSWORD,
     database: process.env.RDS_DB_DATABASE,
-    synchronize: true,
+    // synchronize: true,
     logging: false,
     entities: entities,
     migrations: ["src/migration/**/*.ts"],

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prettier": "^2.0.2",
     "ts-node": "8.5.4",
     "ts-node-dev": "^1.0.0-pre.44",
-    "typescript": "^3.8.0-dev.20200208"
+    "typescript": "^3.8.3"
   },
   "dependencies": {
     "apollo-server": "^2.9.13",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "scripts": {
     "start": "ts-node index.ts",
-    "dev": "ts-node-dev --no-notify --respawn --transpileOnly ./"
+    "dev": "ts-node-dev --no-notify --respawn --transpileOnly ./",
+    "format": "prettier --write src/**/*.ts"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",
@@ -21,7 +22,7 @@
     "@types/ms": "^0.7.31",
     "@types/node": "12.12.16",
     "@types/pg": "^7.11.2",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.2",
     "ts-node": "8.5.4",
     "ts-node-dev": "^1.0.0-pre.44",
     "typescript": "^3.8.0-dev.20200208"

--- a/src/entity/Attempt.ts
+++ b/src/entity/Attempt.ts
@@ -17,10 +17,6 @@ export class Attempt extends Base {
   @Column({ nullable: true })
   date: Date
 
-  @ManyToOne(
-    type => User,
-    user => user.attempts,
-    { nullable: false }
-  )
+  @ManyToOne(type => User, user => user.attempts, { nullable: false })
   user: User
 }

--- a/src/entity/Comment.ts
+++ b/src/entity/Comment.ts
@@ -15,16 +15,9 @@ export class Comment extends Base {
   @Column()
   url: string
 
-  @ManyToOne(
-    type => User,
-    user => user.comments,
-    { nullable: false }
-  )
+  @ManyToOne(type => User, user => user.comments, { nullable: false })
   user: User
 
-  @OneToMany(
-    type => Reaction,
-    reaction => reaction.comment
-  )
+  @OneToMany(type => Reaction, reaction => reaction.comment)
   reactions: Reaction[]
 }

--- a/src/entity/Reaction.ts
+++ b/src/entity/Reaction.ts
@@ -26,17 +26,9 @@ export class Reaction extends Base {
   })
   variant: ReactionVariant
 
-  @ManyToOne(
-    type => Comment,
-    comment => comment.reactions,
-    { nullable: false }
-  )
+  @ManyToOne(type => Comment, comment => comment.reactions, { nullable: false })
   comment: Comment
 
-  @ManyToOne(
-    type => User,
-    user => user.reactions,
-    { nullable: false }
-  )
+  @ManyToOne(type => User, user => user.reactions, { nullable: false })
   user: User
 }

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -37,22 +37,15 @@ export class User extends Base {
   @Column({ nullable: true })
   banned: boolean
 
-  @OneToMany(
-    type => Comment,
-    comment => comment.user
-  )
+  @OneToMany(type => Comment, comment => comment.user)
   comments: Comment[]
 
-  @OneToMany(
-    type => Reaction,
-    reaction => reaction.user
-  )
+  @OneToMany(type => Reaction, reaction => reaction.user)
   reactions: Reaction[]
 
-  @OneToMany(
-    type => Attempt,
-    attempt => attempt.user,
-    { nullable: true, cascade: true }
-  )
+  @OneToMany(type => Attempt, attempt => attempt.user, {
+    nullable: true,
+    cascade: true,
+  })
   attempts: Attempt[]
 }

--- a/src/resolvers/Mutation/createAttempt.ts
+++ b/src/resolvers/Mutation/createAttempt.ts
@@ -1,4 +1,4 @@
-import { Context } from "../../../index"
+import { ResolverFn } from "resolvers"
 import { getUserId } from "../../utils"
 import { User } from "../../entity/User"
 import { Attempt } from "../../entity/Attempt"
@@ -10,12 +10,10 @@ type CreateAttemptArgs = {
   date: Date
 }
 
-export async function createAttempt(
-  parent,
-  { userId, send, grade, date }: CreateAttemptArgs,
-  context: Context,
-  info
-) {
+export const createAttempt: ResolverFn<
+  Attempt,
+  CreateAttemptArgs
+> = async function (parent, { userId, send, grade, date }, context, info) {
   const { connection } = context
   /**
    * @todo use token from headers for userId

--- a/src/resolvers/Mutation/createComment.ts
+++ b/src/resolvers/Mutation/createComment.ts
@@ -1,10 +1,15 @@
-import { Context } from "../../../index"
+import { ResolverFn } from "resolvers"
 import { getUserId } from "../../utils"
 import { User } from "../../entity/User"
 import { Comment } from "../../entity/Comment"
 import { NEW_COMMENT } from "../eventLabels"
 
-export async function createComment(parent, args, context: Context, info) {
+export const createComment: ResolverFn<Comment> = async function (
+  parent,
+  args,
+  context,
+  info
+) {
   const { connection, pubsub } = context
   const userId = getUserId(context)
   if (!userId) throw new Error("No userId in token")

--- a/src/resolvers/Mutation/deleteCommentById.ts
+++ b/src/resolvers/Mutation/deleteCommentById.ts
@@ -1,11 +1,11 @@
-import { Context } from "../../../index"
+import { ResolverFn } from "resolvers"
 import { getUserId } from "../../utils"
 import { Comment } from "../../entity/Comment"
 
-export async function deleteCommentById(
+export const deleteCommentById: ResolverFn<Comment> = async function (
   parent,
   { id },
-  context: Context,
+  context,
   info
 ) {
   const { connection } = context

--- a/src/resolvers/Mutation/login.ts
+++ b/src/resolvers/Mutation/login.ts
@@ -1,7 +1,7 @@
 import * as jwt from "jsonwebtoken"
 import * as bcrypt from "bcryptjs"
 
-import { Context } from "../../../index"
+import { ResolverFn } from "resolvers"
 import { APP_SECRET, TokenPayload } from "../../utils"
 import { User } from "../../entity/User"
 
@@ -9,10 +9,14 @@ type LoginArgs = {
   password: string
   email: string
 }
-export async function login(
+type LoginReturn = {
+  token: string
+  user: User
+}
+export const login: ResolverFn<LoginReturn, LoginArgs> = async function (
   parent,
-  args: LoginArgs,
-  { connection }: Context,
+  args,
+  { connection },
   info
 ) {
   const user = await connection

--- a/src/resolvers/Mutation/reactToComment.ts
+++ b/src/resolvers/Mutation/reactToComment.ts
@@ -1,4 +1,4 @@
-import { Context } from "../../../index"
+import { ResolverFn } from "resolvers"
 import { getUserId } from "../../utils"
 import { User } from "../../entity/User"
 import { Comment } from "../../entity/Comment"
@@ -10,12 +10,10 @@ type ReactToCommentArgs = {
   commentId: number
   variant: ReactionVariant
 }
-export async function reactToComment(
-  parent,
-  args: ReactToCommentArgs,
-  context: Context,
-  info
-) {
+export const reactToComment: ResolverFn<
+  Reaction,
+  ReactToCommentArgs
+> = async function (parent, args, context, info) {
   const { connection, pubsub } = context
   /** The one who is reacting */
   const userId = getUserId(context)

--- a/src/resolvers/Mutation/requestPasswordResetLink.ts
+++ b/src/resolvers/Mutation/requestPasswordResetLink.ts
@@ -2,7 +2,7 @@ import * as jwt from "jsonwebtoken"
 import ms from "ms"
 import { SESV2 } from "aws-sdk"
 
-import { Context } from "../../../index"
+import { ResolverFn } from "resolvers"
 import { APP_SECRET } from "../../utils"
 import { User } from "../../entity/User"
 import { createPasswordResetEmailHTMLString } from "../password_reset_email"
@@ -23,12 +23,10 @@ export type RequestPasswordResetLinkArgs = {
  *
  * Sends a password reset link with token in URL parameters
  */
-export async function requestPasswordResetLink(
-  parent,
-  args: RequestPasswordResetLinkArgs,
-  { connection, sesv2, req }: Context,
-  info
-) {
+export const requestPasswordResetLink: ResolverFn<
+  { message: string },
+  RequestPasswordResetLinkArgs
+> = async function (parent, args, { connection, sesv2, req }, info) {
   const user = await connection
     .getRepository(User)
     .createQueryBuilder("user")

--- a/src/resolvers/Mutation/resetPassword.ts
+++ b/src/resolvers/Mutation/resetPassword.ts
@@ -3,19 +3,17 @@ import * as bcrypt from "bcryptjs"
 import ms from "ms"
 import { SESV2 } from "aws-sdk"
 
-import { Context } from "../../../index"
+import { ResolverFn } from "resolvers"
 import { APP_SECRET } from "../../utils"
 import { User } from "../../entity/User"
 
 type ResetPasswordArgs = {
   password: string
 }
-export async function resetPassword(
-  parent,
-  args: ResetPasswordArgs,
-  { connection, ...context }: Context,
-  info
-) {
+export const resetPassword: ResolverFn<
+  User,
+  ResetPasswordArgs
+> = async function (parent, args, { connection, ...context }, info) {
   const Authorization = context.req.get("Authorization")
   if (!Authorization) throw new Error("Missing header") // best practices?
 

--- a/src/resolvers/Mutation/s3GetSignedPutObjectUrl.ts
+++ b/src/resolvers/Mutation/s3GetSignedPutObjectUrl.ts
@@ -1,4 +1,4 @@
-import { Context } from "../../../index"
+import { ResolverFn } from "resolvers"
 import { getUserId } from "../../utils"
 import { User } from "../../entity/User"
 
@@ -6,16 +6,18 @@ type S3GetSignedPutObjectUrlArgs = {
   fileName: string
   fileType: "image/jpeg" | "image/png"
 }
+type S3GetSignedPutObjectUrlReturn = {
+  signedPutObjectUrl
+  objectUrl
+}
 
 /**
  * Get a signed s3 url to POST an image to S3
  */
-export async function s3GetSignedPutObjectUrl(
-  parent,
-  args: S3GetSignedPutObjectUrlArgs,
-  context: Context,
-  info
-) {
+export const s3GetSignedPutObjectUrl: ResolverFn<
+  S3GetSignedPutObjectUrlReturn,
+  S3GetSignedPutObjectUrlArgs
+> = async function (parent, args, context, info) {
   const userId = getUserId(context)
   if (!userId) throw new Error("No userId in token")
   const { s3, connection } = context

--- a/src/resolvers/Mutation/signup.ts
+++ b/src/resolvers/Mutation/signup.ts
@@ -2,7 +2,7 @@ import * as jwt from "jsonwebtoken"
 import * as bcrypt from "bcryptjs"
 import fetch from "isomorphic-fetch"
 
-import { Context } from "../../../index"
+import { ResolverFn } from "resolvers"
 import { APP_SECRET } from "../../utils"
 import { User } from "../../entity/User"
 
@@ -13,10 +13,14 @@ type SignupArgs = {
   lastName: string
   email: string
 }
-export async function signup(
+type SignupReturn = {
+  token: string
+  user: User
+}
+export const signup: ResolverFn<SignupReturn, SignupArgs> = async function (
   parent,
-  args: SignupArgs,
-  { connection }: Context,
+  args,
+  { connection },
   info
 ) {
   try {

--- a/src/resolvers/Mutation/updatePassword.ts
+++ b/src/resolvers/Mutation/updatePassword.ts
@@ -1,7 +1,7 @@
 import * as jwt from "jsonwebtoken"
 import * as bcrypt from "bcryptjs"
 
-import { Context } from "../../../index"
+import { ResolverFn } from "resolvers"
 import { APP_SECRET, getUserId } from "../../utils"
 import { User } from "../../entity/User"
 
@@ -9,13 +9,15 @@ type UpdatedPasswordArgs = {
   password: string
   newPassword: string
 }
-export async function updatePassword(
-  parent,
-  args: UpdatedPasswordArgs,
-  { connection, ...context }: Context,
-  info
-) {
-  const userId = getUserId(context as Context)
+type UpdatedPasswordReturn = {
+  token: string
+  user: User
+}
+export const updatePassword: ResolverFn<
+  UpdatedPasswordReturn,
+  UpdatedPasswordArgs
+> = async function (parent, args, { connection, ...context }, info) {
+  const userId = getUserId(context)
   if (!userId) throw new Error("No userId in token")
 
   const user = await connection

--- a/src/resolvers/Mutation/updateUserAvatar.ts
+++ b/src/resolvers/Mutation/updateUserAvatar.ts
@@ -1,16 +1,14 @@
-import { Context } from "../../../index"
+import { ResolverFn } from "resolvers"
 import { getUserId } from "../../utils"
 import { User } from "../../entity/User"
 
 type UpdateUserAvatarArgs = {
   avatarUrl: string
 }
-export async function updateUserAvatar(
-  parent,
-  { avatarUrl }: UpdateUserAvatarArgs,
-  context: Context,
-  info
-) {
+export const updateUserAvatar: ResolverFn<
+  User,
+  UpdateUserAvatarArgs
+> = async function (parent, { avatarUrl }, context, info) {
   const { connection } = context
   const userId = getUserId(context)
   if (!userId) throw new Error("No userId in token")

--- a/src/resolvers/Query/getAllAttempts.ts
+++ b/src/resolvers/Query/getAllAttempts.ts
@@ -1,10 +1,10 @@
-import { Context } from "index"
+import { ResolverFn } from "resolvers"
 import { Attempt } from "../../entity/Attempt"
 
-export async function getAllAttempts(
+export const getAllAtempts: ResolverFn<Attempt[]> = async function (
   parent,
   args,
-  { connection }: Context,
+  { connection },
   info
 ) {
   const attempts = await connection

--- a/src/resolvers/Query/getAllAttempts.ts
+++ b/src/resolvers/Query/getAllAttempts.ts
@@ -1,7 +1,7 @@
 import { ResolverFn } from "resolvers"
 import { Attempt } from "../../entity/Attempt"
 
-export const getAllAtempts: ResolverFn<Attempt[]> = async function (
+export const getAllAttempts: ResolverFn<Attempt[]> = async function (
   parent,
   args,
   { connection },

--- a/src/resolvers/Query/getAllComments.ts
+++ b/src/resolvers/Query/getAllComments.ts
@@ -1,10 +1,10 @@
-import { Context } from "index"
+import { ResolverFn } from "resolvers"
 import { Comment } from "../../entity/Comment"
 
-export async function getAllComments(
+export const getAllComments: ResolverFn<Comment[]> = async function (
   parent,
   args,
-  { connection }: Context,
+  { connection },
   info
 ) {
   const comments = await connection

--- a/src/resolvers/Query/getAllReactions.ts
+++ b/src/resolvers/Query/getAllReactions.ts
@@ -1,10 +1,10 @@
-import { Context } from "index"
+import { ResolverFn } from "resolvers"
 import { Reaction } from "../../entity/Reaction"
 
-export async function getAllReactions(
+export const getAllReactions: ResolverFn<Reaction[]> = async function (
   parent,
   args,
-  { connection }: Context,
+  { connection },
   info
 ) {
   const reactions = await connection

--- a/src/resolvers/Query/getAllUsers.ts
+++ b/src/resolvers/Query/getAllUsers.ts
@@ -1,7 +1,12 @@
-import { Context } from "index"
+import { ResolverFn } from "resolvers"
 import { User } from "../../entity/User"
 
-export async function getAllUsers(parent, args, { connection }: Context, info) {
+export const getAllUsers: ResolverFn<User[]> = async function (
+  parent,
+  args,
+  { connection },
+  info
+) {
   const users = await connection
     .getRepository(User)
     .createQueryBuilder("user")

--- a/src/resolvers/Query/getAttemptsByUserId.ts
+++ b/src/resolvers/Query/getAttemptsByUserId.ts
@@ -1,15 +1,13 @@
-import { Context } from "index"
+import { ResolverFn } from "resolvers"
 import { Attempt } from "../../entity/Attempt"
 
 type GetAttemptsByUserIdArgs = {
   userId: number
 }
-export async function getAttemptsByUserId(
-  parent,
-  { userId }: GetAttemptsByUserIdArgs,
-  { connection }: Context,
-  info
-) {
+export const getAttemptsByUserId: ResolverFn<
+  Attempt[],
+  GetAttemptsByUserIdArgs
+> = async function (parent, { userId }, { connection }, info) {
   const attempts = await connection
     .getRepository(Attempt)
     .createQueryBuilder("attempt")

--- a/src/resolvers/Query/getCommentsByUrl.ts
+++ b/src/resolvers/Query/getCommentsByUrl.ts
@@ -1,4 +1,4 @@
-import { Context } from "index"
+import { ResolverFn } from "resolvers"
 import { Comment } from "../../entity/Comment"
 
 enum CommentOrderByInput {
@@ -11,10 +11,13 @@ type GetCommentsByUrlArgs = {
   skip: number
   take: number
 }
-export async function getCommentsByUrl(
+export const getCommentsByUrl: ResolverFn<
+  Comment[],
+  GetCommentsByUrlArgs
+> = async function (
   parent,
   { url, filter, skip, take }: GetCommentsByUrlArgs,
-  { connection }: Context,
+  { connection },
   info
 ) {
   const comments = await connection

--- a/src/resolvers/Query/getFirstUser.ts
+++ b/src/resolvers/Query/getFirstUser.ts
@@ -1,10 +1,10 @@
-import { Context } from "index"
+import { ResolverFn } from "resolvers"
 import { User } from "../../entity/User"
 
-export async function getFirstUser(
+export const getFirstUser: ResolverFn<User> = async function (
   parent,
   args,
-  { connection }: Context,
+  { connection },
   info
 ) {
   const firstUser = await connection

--- a/src/resolvers/Query/getUserById.ts
+++ b/src/resolvers/Query/getUserById.ts
@@ -1,7 +1,13 @@
-import { Context } from "index"
+import { ResolverFn } from "resolvers"
 import { User } from "../../entity/User"
 
-export async function getUserById(parent, args, { connection }: Context, info) {
+type GetUserByIdArgs = { id: string }
+export const getUserById: ResolverFn<User, GetUserByIdArgs> = async function (
+  parent,
+  args,
+  { connection },
+  info
+) {
   const user = await connection
     .getRepository(User)
     .createQueryBuilder("user")

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,6 +1,14 @@
+import { Context } from "../../index"
 import * as Subscription from "./Subscription"
 import * as Query from "./Query"
 import * as Mutation from "./Mutation"
+
+export type ResolverFn<R = any, A = any> = (
+  parent: any,
+  args: A,
+  context: Context,
+  info: any
+) => Promise<R>
 
 export const resolvers = {
   Query,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,7 +18,7 @@ export type TokenPayload = { userId: number }
  *   - "invalid signature"
  * @param context the context object from a graphql resolver
  */
-export function getUserId(context: Context): number {
+export function getUserId(context: Pick<Context, "req">): number {
   const Authorization = context.req.get("Authorization")
   if (Authorization) {
     const token = Authorization.replace("Bearer ", "")

--- a/yarn.lock
+++ b/yarn.lock
@@ -2400,10 +2400,10 @@ typeorm@0.2.21:
     yargonaut "^1.1.2"
     yargs "^13.2.1"
 
-typescript@^3.8.0-dev.20200208:
-  version "3.8.0-dev.20200208"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.0-dev.20200208.tgz#3cd1ee025932c88ff78831f3629e99b1995e1de5"
-  integrity sha512-/n4f+RIfoHvEmXprHjE7dHzGlDzD0wpqpvHBXBtwaCi1wp8zsGqA07v1UPijR1xBqumO5FFDMEPIuu7fEDJemA==
+typescript@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1911,10 +1911,10 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
+  integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==
 
 proxy-addr@~2.0.5:
   version "2.0.5"


### PR DESCRIPTION
# Description

This turns TypeORM's `synchronize: false`
- should generate and run migrations instead.

This adds `ResolverFn` type to reuse for every new resolver.